### PR TITLE
feat: implement custom error classes

### DIFF
--- a/src/errors/MiniFetchError.ts
+++ b/src/errors/MiniFetchError.ts
@@ -1,0 +1,31 @@
+import type { MiniFetchMethod } from '../types/MiniFetch'
+
+export class HttpError extends Error {
+  constructor(
+    public method: MiniFetchMethod,
+    public url: string,
+    public status: number,
+    public response?: Response,
+  ) {
+    super(`Request failed with HTTP ${status}: ${method} ${url}`)
+    this.name = 'HttpError'
+  }
+}
+
+export class TimeoutError extends Error {
+  constructor(
+    public method: MiniFetchMethod,
+    public url: string,
+    public timeout: number,
+  ) {
+    super(`Request timed out after ${timeout}ms: ${method} ${url}`)
+    this.name = 'TimeoutError'
+  }
+}
+
+export class FetchError extends Error {
+  constructor(message: string) {
+    super(`Request failed with Fetch Error: ${message}`)
+    this.name = 'FetchError'
+  }
+}


### PR DESCRIPTION
- Replaced native `Error` with `HttpError`, `TimeoutError`, `FetchError` to unify error handling in miniFetch.