### PR TITLE
refactor: add MiniFetchMethod type and restructure MiniFetchRequest/O…

### DIFF
--- a/src/core/miniFetch.ts
+++ b/src/core/miniFetch.ts
@@ -1,5 +1,5 @@
 import type { MiniFetchOptions, MiniFetchResponse } from '../types/MiniFetch'
-import { HttpError, TimeoutError, FetchError } from '../errors/MiniFetchError'
+import { HttpError, TimeoutError, RequestError } from '../errors/MiniFetchError'
 import { isSerializable } from '../utils/bodySerializer'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -23,12 +23,17 @@ export async function miniFetch<T = any>(
     abortTimer = setTimeout(() => abortController.abort(), timeout)
   }
 
-  const signal =
-    abortController && externalSignal
-      ? AbortSignal.any([abortController.signal, externalSignal])
-      : (abortController?.signal ?? externalSignal)
-
   try {
+    const signal = (() => {
+      if (abortController && externalSignal) {
+        if (typeof AbortSignal.any !== 'function') {
+          throw new RequestError('AbortSignal.any is not supported in this runtime')
+        }
+        return AbortSignal.any([abortController.signal, externalSignal])
+      }
+      return abortController?.signal ?? externalSignal
+    })()
+
     const mergedHeaders = new Headers(headers)
     let requestBody: BodyInit | undefined
     if (method !== 'GET' && body !== undefined) {
@@ -64,13 +69,13 @@ export async function miniFetch<T = any>(
     } else if (responseType === 'arrayBuffer') {
       data = (await response.arrayBuffer()) as T
     } else {
-      throw new FetchError(`Unsupported responseType: ${responseType}`)
+      throw new RequestError(`Unsupported responseType: ${responseType}`)
     }
 
     const miniResponse: MiniFetchResponse<T> = Object.assign(response, { data })
     return miniResponse
   } catch (error: unknown) {
-    if (!(error instanceof Error) || error instanceof HttpError) {
+    if (!(error instanceof Error) || error instanceof RequestError) {
       throw error
     }
     if (error.name === 'AbortError' || error.message.includes('aborted')) {
@@ -79,7 +84,7 @@ export async function miniFetch<T = any>(
       }
       throw error
     }
-    throw new FetchError(error.message)
+    throw new RequestError(error.message)
   } finally {
     if (abortTimer !== null) {
       clearTimeout(abortTimer)

--- a/src/core/miniFetch.ts
+++ b/src/core/miniFetch.ts
@@ -8,19 +8,25 @@ export async function miniFetch<T = any>(
   options?: MiniFetchOptions,
 ): Promise<MiniFetchResponse<T>> {
   const {
-    autoParseJson = true,
+    responseType = 'json',
     timeout = 0,
     method = 'GET',
     body,
     headers,
+    signal: externalSignal,
     ...rest
   } = options || {}
 
-  const abortController = new AbortController()
+  const abortController = timeout > 0 ? new AbortController() : null
   let abortTimer: ReturnType<typeof setTimeout> | null = null
-  if (timeout > 0) {
+  if (abortController) {
     abortTimer = setTimeout(() => abortController.abort(), timeout)
   }
+
+  const signal =
+    abortController && externalSignal
+      ? AbortSignal.any([abortController.signal, externalSignal])
+      : (abortController?.signal ?? externalSignal)
 
   try {
     const mergedHeaders = new Headers(headers)
@@ -40,7 +46,7 @@ export async function miniFetch<T = any>(
       method,
       headers: mergedHeaders,
       body: requestBody,
-      signal: abortController.signal,
+      signal,
       ...rest,
     })
 
@@ -48,18 +54,35 @@ export async function miniFetch<T = any>(
       throw new HttpError(method, url, response.status)
     }
 
-    const data = autoParseJson ? await response.json() : undefined
+    let data: T | undefined
+    if (responseType === 'json') {
+      data = await response.json()
+    } else if (responseType === 'blob') {
+      data = (await response.blob()) as T
+    } else if (responseType === 'text') {
+      data = (await response.text()) as T
+    } else if (responseType === 'arrayBuffer') {
+      data = (await response.arrayBuffer()) as T
+    } else {
+      throw new FetchError(`Unsupported responseType: ${responseType}`)
+    }
+
     const miniResponse: MiniFetchResponse<T> = Object.assign(response, { data })
     return miniResponse
   } catch (error: unknown) {
-    if (!(error instanceof Error)) {
+    if (!(error instanceof Error) || error instanceof HttpError) {
       throw error
     }
     if (error.name === 'AbortError' || error.message.includes('aborted')) {
-      throw new TimeoutError(method, url, timeout)
+      if (timeout > 0 && abortController?.signal.aborted) {
+        throw new TimeoutError(method, url, timeout)
+      }
+      throw error
     }
     throw new FetchError(error.message)
   } finally {
-    if (abortTimer !== null) clearTimeout(abortTimer)
+    if (abortTimer !== null) {
+      clearTimeout(abortTimer)
+    }
   }
 }

--- a/src/errors/MiniFetchError.ts
+++ b/src/errors/MiniFetchError.ts
@@ -1,8 +1,8 @@
-import type { MiniFetchMethod } from '../types/MiniFetch'
+import type { MiniFetchMethodType } from '../types/MiniFetch'
 
 export class HttpError extends Error {
   constructor(
-    public method: MiniFetchMethod,
+    public method: MiniFetchMethodType,
     public url: string,
     public status: number,
     public response?: Response,
@@ -14,7 +14,7 @@ export class HttpError extends Error {
 
 export class TimeoutError extends Error {
   constructor(
-    public method: MiniFetchMethod,
+    public method: MiniFetchMethodType,
     public url: string,
     public timeout: number,
   ) {

--- a/src/errors/MiniFetchError.ts
+++ b/src/errors/MiniFetchError.ts
@@ -1,6 +1,13 @@
 import type { MiniFetchMethodType } from '../types/MiniFetch'
 
-export class HttpError extends Error {
+export class RequestError extends Error {
+  constructor(message: string) {
+    super(`Request failed with Error: ${message}`)
+    this.name = 'RequestError'
+  }
+}
+
+export class HttpError extends RequestError {
   constructor(
     public method: MiniFetchMethodType,
     public url: string,
@@ -12,7 +19,7 @@ export class HttpError extends Error {
   }
 }
 
-export class TimeoutError extends Error {
+export class TimeoutError extends RequestError {
   constructor(
     public method: MiniFetchMethodType,
     public url: string,
@@ -20,12 +27,5 @@ export class TimeoutError extends Error {
   ) {
     super(`Request timed out after ${timeout}ms: ${method} ${url}`)
     this.name = 'TimeoutError'
-  }
-}
-
-export class FetchError extends Error {
-  constructor(message: string) {
-    super(`Request failed with Fetch Error: ${message}`)
-    this.name = 'FetchError'
   }
 }

--- a/src/types/MiniFetch.ts
+++ b/src/types/MiniFetch.ts
@@ -1,8 +1,17 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-export interface MiniFetchOptions<T = any> extends Omit<RequestInit, 'body'> {
-  body?: T
+export type MiniFetchMethod = 'GET' | 'POST' | 'PATCH' | 'PUT' | 'DELETE'
+
+export interface MiniFetchOptions extends MiniFetchRequest {
   autoParseJson?: boolean
   timeout?: number
+}
+
+export interface MiniFetchRequest<T = any> extends Omit<RequestInit, 'body'> {
+  body?: T
+}
+
+export interface MiniFetchResponse<T = any> extends Response {
+  data?: T
 }
 
 export interface MiniFetchApi {
@@ -11,13 +20,4 @@ export interface MiniFetchApi {
   patch: <T = any>(url: string, options?: MiniFetchOptions) => Promise<MiniFetchResponse<T>>
   put: <T = any>(url: string, options?: MiniFetchOptions) => Promise<MiniFetchResponse<T>>
   delete: <T = any>(url: string, options?: MiniFetchOptions) => Promise<MiniFetchResponse<T>>
-}
-
-export interface MiniFetchRequest extends RequestInit {
-  autoParseJson?: boolean
-  timeout?: number
-}
-
-export interface MiniFetchResponse<T = any> extends Response {
-  data?: T
 }

--- a/src/types/MiniFetch.ts
+++ b/src/types/MiniFetch.ts
@@ -1,12 +1,14 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-export type MiniFetchMethod = 'GET' | 'POST' | 'PATCH' | 'PUT' | 'DELETE'
+export type MiniFetchMethodType = 'GET' | 'POST' | 'PATCH' | 'PUT' | 'DELETE'
+export type MiniFetchResponseType = 'json' | 'blob' | 'text' | 'arrayBuffer'
 
-export interface MiniFetchOptions extends MiniFetchRequest {
-  autoParseJson?: boolean
+export interface MiniFetchOptions<T = any> extends MiniFetchRequest<T> {
+  responseType?: MiniFetchResponseType
   timeout?: number
 }
 
-export interface MiniFetchRequest<T = any> extends Omit<RequestInit, 'body'> {
+export interface MiniFetchRequest<T = any> extends Omit<RequestInit, 'body' | 'method'> {
+  method?: MiniFetchMethodType
   body?: T
 }
 

--- a/tests/core/miniFetch.test.ts
+++ b/tests/core/miniFetch.test.ts
@@ -1,7 +1,6 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
+import type { MiniFetchResponseType } from '../../src/types/MiniFetch'
 import { miniFetch } from '../../src/core/miniFetch'
 import { TimeoutError } from '../../src/errors/MiniFetchError'
 
@@ -102,7 +101,7 @@ describe('miniFetch', () => {
 
     await expect(
       miniFetch('https://fake-url.com/', {
-        responseType: 'xml' as any,
+        responseType: 'xml' as unknown as MiniFetchResponseType,
       }),
     ).rejects.toThrow(/Unsupported responseType/)
   })

--- a/tests/core/miniFetch.test.ts
+++ b/tests/core/miniFetch.test.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
 import { miniFetch } from '../../src/core/miniFetch'
@@ -15,7 +17,7 @@ describe('miniFetch', () => {
   afterEach(() => {
     vi.useRealTimers() // fake timer 비활성화
   })
-  // 성공 응답 검증
+
   it('should return data on successful response', async () => {
     globalThis.fetch = vi.fn().mockResolvedValue({
       ok: true,
@@ -25,27 +27,86 @@ describe('miniFetch', () => {
     } as Response)
 
     const response = await miniFetch<FakeResponse>('https://fake-url.com/')
-    expect(response.data?.message).toBe('hello')
+    expect(response.data).toEqual({ message: 'hello' })
     expect(response.ok).toBe(true)
     expect(response.status).toBe(200)
   })
-  // autoParseJson 옵션 false일 때 data가 undefined인지 검증
-  it('should return undefined data when autoParse is false', async () => {
+
+  it('should return data when responseType is "json"', async () => {
     globalThis.fetch = vi.fn().mockResolvedValue({
       ok: true,
       status: 200,
       json: async () => ({ message: 'hello' }),
-      text: async () => 'hello',
     } as Response)
 
     const response = await miniFetch<FakeResponse>('https://fake-url.com/', {
-      autoParseJson: false,
+      responseType: 'json',
     })
-    expect(response.data).toBeUndefined()
+    expect(response.data).toEqual({ message: 'hello' })
     expect(response.ok).toBe(true)
     expect(response.status).toBe(200)
   })
-  // timeout 발생 시 TimeoutError가 throw 되는지 검증
+
+  it('should return data when responseType is "text"', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => 'hello',
+    } as Response)
+
+    const response = await miniFetch<string>('https://fake-url.com/', {
+      responseType: 'text',
+    })
+    expect(response.data).toBe('hello')
+    expect(response.ok).toBe(true)
+    expect(response.status).toBe(200)
+  })
+
+  it('should return data when responseType is "blob"', async () => {
+    const fakeBlob = new Blob(['hello'], { type: 'text/plain' })
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      blob: async () => fakeBlob,
+    } as Response)
+
+    const response = await miniFetch<Blob>('https://fake-url.com/', {
+      responseType: 'blob',
+    })
+    expect(response.data).toBeInstanceOf(Blob)
+    expect(response.data).toBe(fakeBlob)
+    expect(response.status).toBe(200)
+  })
+
+  it('should return data when responseType is "arrayBuffer"', async () => {
+    const fakeBuffer = new ArrayBuffer(8)
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      arrayBuffer: async () => fakeBuffer,
+    } as Response)
+
+    const response = await miniFetch<ArrayBuffer>('https://fake-url.com/', {
+      responseType: 'arrayBuffer',
+    })
+    expect(response.data).toBeInstanceOf(ArrayBuffer)
+    expect(response.data).toBe(fakeBuffer)
+    expect(response.status).toBe(200)
+  })
+
+  it('should throw FetchError on unsupported responseTypes', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+    } as Response)
+
+    await expect(
+      miniFetch('https://fake-url.com/', {
+        responseType: 'xml' as any,
+      }),
+    ).rejects.toThrow(/Unsupported responseType/)
+  })
+
   it('should reject with TimeoutError when request times out', async () => {
     globalThis.fetch = vi.fn().mockImplementation(
       (_url, { signal }) =>
@@ -64,7 +125,7 @@ describe('miniFetch', () => {
 
     await expect(fetchPromise).rejects.toThrow(/Request timed out/i)
   })
-  // HTTP 에러 발생 시 HttpError가 throw 되는지 검증
+
   it('should reject with HttpError on HTTP error response', async () => {
     globalThis.fetch = vi.fn().mockResolvedValue({
       ok: false,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "es2020",
     "module": "esnext",
     "declaration": true,
+    "rootDir": "src",
     "outDir": "dist",
     "strict": true,
     "noImplicitAny": true,


### PR DESCRIPTION
- support json, blob, text, arrayBuffer response parsing
- throw FetchError on unsupported responseType
- re-throw HttpError and non-Error values directly
- distinguish timeout abort from manual abort using abortController.signal.aborted
- extract signal from options to avoid rest spread override
- merge timeout signal and external signal using AbortSignal.any()